### PR TITLE
Allow to mark files as executable

### DIFF
--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -5,7 +5,7 @@ require "pathname"
 module Dependabot
   class DependencyFile
     attr_accessor :name, :content, :directory, :type, :support_file,
-                  :symlink_target, :content_encoding, :operation
+                  :symlink_target, :content_encoding, :operation, :execute_filemode
 
     class ContentEncoding
       UTF_8 = "utf-8"
@@ -20,7 +20,8 @@ module Dependabot
 
     def initialize(name:, content:, directory: "/", type: "file",
                    support_file: false, symlink_target: nil,
-                   content_encoding: ContentEncoding::UTF_8, deleted: false, operation: Operation::UPDATE)
+                   content_encoding: ContentEncoding::UTF_8, deleted: false, operation: Operation::UPDATE,
+                   execute_filemode: false)
       @name = name
       @content = content
       @directory = clean_directory(directory)
@@ -28,6 +29,7 @@ module Dependabot
       @support_file = support_file
       @content_encoding = content_encoding
       @operation = operation
+      @execute_filemode = execute_filemode
 
       # Make deleted override the operation. Deleted is kept when operation
       # was introduced to keep compatibility with downstream dependants.
@@ -55,7 +57,8 @@ module Dependabot
         "support_file" => support_file,
         "content_encoding" => content_encoding,
         "deleted" => deleted,
-        "operation" => operation
+        "operation" => operation,
+        "execute_filemode" => execute_filemode
       }
 
       details["symlink_target"] = symlink_target if symlink_target
@@ -96,6 +99,10 @@ module Dependabot
 
     def deleted?
       deleted
+    end
+
+    def execute_filemode?
+      execute_filemode
     end
 
     def binary?

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -193,7 +193,7 @@ module Dependabot
             {
               path: (file.symlink_target ||
                      file.path).sub(%r{^/}, ""),
-              mode: "100644",
+              mode: file.execute_filemode? ? "100755" : "100644",
               type: "blob"
             }.merge(content)
           end

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -114,6 +114,14 @@ module Dependabot
           }
         end
 
+        files.select(&:execute_filemode?).each do |file|
+          actions << {
+            action: "chmod",
+            file_path: file.path,
+            execute_filemode: true
+          }
+        end
+
         gitlab_client_for_source.create_commit(
           source.repo,
           branch_name,

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -146,7 +146,7 @@ module Dependabot
             {
               path: (file.symlink_target ||
                      file.path).sub(%r{^/}, ""),
-              mode: "100644",
+              mode: file.execute_filemode? ? "100755" : "100644",
               type: "blob"
             }.merge(content)
           end

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -83,6 +83,14 @@ module Dependabot
           }
         end
 
+        files.select(&:execute_filemode?).each do |file|
+          actions << {
+            action: "chmod",
+            file_path: file.path,
+            execute_filemode: true
+          }
+        end
+
         gitlab_client_for_source.create_commit(
           source.repo,
           merge_request.source_branch,

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -87,6 +88,11 @@ RSpec.describe Dependabot::DependencyFile do
         expect(file.deleted).to be_falsey
         expect(file.deleted?).to be_falsey
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
+      end
+
+      it "indicates the filemode correctly" do
+        expect(file.execute_filemode).to be_falsey
+        expect(file.execute_filemode?).to be_falsey
       end
     end
 
@@ -105,6 +111,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "symlink",
           "support_file" => false,
           "symlink_target" => "nested/Gemfile",
@@ -135,6 +142,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -164,6 +172,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -193,6 +202,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -222,6 +232,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -252,6 +263,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -264,6 +276,36 @@ RSpec.describe Dependabot::DependencyFile do
         expect(file.deleted).to be_truthy
         expect(file.deleted?).to be_truthy
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
+      end
+    end
+
+    context "with an executable file" do
+      let(:file) do
+        described_class.new(
+          name: "Gemfile",
+          content: "a",
+          operation: Dependabot::DependencyFile::Operation::UPDATE,
+          execute_filemode: true
+        )
+      end
+
+      it "returns the correct array" do
+        expect(subject).to eq(
+          "name" => "Gemfile",
+          "content" => "a",
+          "directory" => "/",
+          "execute_filemode" => true,
+          "type" => "file",
+          "support_file" => false,
+          "content_encoding" => "utf-8",
+          "deleted" => false,
+          "operation" => Dependabot::DependencyFile::Operation::UPDATE
+        )
+      end
+
+      it "indicates the filemode correctly" do
+        expect(file.execute_filemode).to be_truthy
+        expect(file.execute_filemode?).to be_truthy
       end
     end
   end

--- a/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
       "password" => "token"
     }]
   end
-  let(:files) { [gemfile, gemfile_lock, created_file, deleted_file] }
+  let(:files) { [gemfile, gemfile_lock, created_file, created_executable, deleted_file] }
   let(:commit_message) { "Commit msg" }
   let(:pr_description) { "PR msg" }
   let(:pr_name) { "PR name" }
@@ -87,6 +87,14 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
       name: "created-file",
       content: "created",
       operation: Dependabot::DependencyFile::Operation::CREATE
+    )
+  end
+  let(:created_executable) do
+    Dependabot::DependencyFile.new(
+      name: "created-executable-file",
+      content: "created-executable",
+      operation: Dependabot::DependencyFile::Operation::CREATE,
+      execute_filemode: true
     )
   end
   let(:deleted_file) do
@@ -161,9 +169,19 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
                 content: created_file.content
               },
               {
+                action: "create",
+                file_path: created_executable.path,
+                content: created_executable.content
+              },
+              {
                 action: "delete",
                 file_path: deleted_file.path,
                 content: ""
+              },
+              {
+                action: "chmod",
+                file_path: created_executable.path,
+                execute_filemode: true
               }
             ]
           }

--- a/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
   let(:source) do
     Dependabot::Source.new(provider: "gitlab", repo: "gocardless/bump")
   end
-  let(:files) { [gemfile, gemfile_lock, created_file, deleted_file] }
+  let(:files) { [gemfile, gemfile_lock, created_file, created_executable, deleted_file] }
   let(:base_commit) { "basecommitsha" }
   let(:old_commit) { "oldcommitsha" }
   let(:merge_request_number) do
@@ -57,6 +57,14 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
       name: "created-file",
       content: "created",
       operation: Dependabot::DependencyFile::Operation::CREATE
+    )
+  end
+  let(:created_executable) do
+    Dependabot::DependencyFile.new(
+      name: "created-executable-file",
+      content: "created-executable",
+      operation: Dependabot::DependencyFile::Operation::CREATE,
+      execute_filemode: true
     )
   end
   let(:deleted_file) do
@@ -170,9 +178,19 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
                 content: created_file.content
               },
               {
+                action: "create",
+                file_path: created_executable.path,
+                content: created_executable.content
+              },
+              {
                 action: "delete",
                 file_path: deleted_file.path,
                 content: ""
+              },
+              {
+                action: "chmod",
+                file_path: created_executable.path,
+                execute_filemode: true
               }
             ],
             force: true,


### PR DESCRIPTION
So far all files have been assumed to be non-executable. For most dependencies this is fine, because only metadata files are being touched.

However, custom FileUpdater implementations may have the need to create files that are marked as executable.

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
